### PR TITLE
Make cluster search less crystal clear

### DIFF
--- a/heimdall
+++ b/heimdall
@@ -110,7 +110,7 @@ case ${args[0]} in
 
             echo "[INFO] Looking"
 
-            CLUSTER=`aws ecs list-clusters | jq -r ".clusterArns[] | select(. | contains (\"$SEARCH_CLUSTER\"))"`
+            CLUSTER=`aws ecs list-clusters | jq -r ".clusterArns[] | select(. | match (\"$SEARCH_CLUSTER\$\"))"`
             if (( `echo $CLUSTER | wc -w` > 1 ))
             then
                 ee "[ERROR] More than one matching cluster arn found"


### PR DESCRIPTION
Summary:
Using contains is a fuzzy search which can return multiple results even
if your query matches exactly. This change will make it less fuzzy since
you're probably not intending to "search" for a cluster.