### PR TITLE
new: pre-configured profiles

### DIFF
--- a/heimdall
+++ b/heimdall
@@ -68,6 +68,23 @@ while [[ "$#" > 0 ]]; do
                 shift 2
             fi
             ;;
+        --profile)
+            if [[ ! -z ${PROFILES} ]]; then
+                for profile in $(echo ${PROFILES} | jq -r '. | keys | .[]'); do
+                    # Only override env variables if the provided profile is valid
+                    if [[ ${profile} != ${2} ]]; then
+                        continue
+                    fi
+
+                    AWSCLI_PROFILE=${profile}
+                    profile=$(echo ${PROFILES} | jq -r .\"${AWSCLI_PROFILE}\")
+                    while IFS='|' read key value; do
+                        eval ${key}="'${value}'"
+                    done <<< "$(jq -r 'to_entries | map(.key + "|" + (.value | tostring)) | .[]' <<<"${profile}")"
+                done
+                shift 2
+            fi
+            ;;
         *) args+=("${1}"); shift;; # save argument for later
     esac
 done
@@ -96,6 +113,8 @@ then
     echo "  service#cluster:            Logs you into a specific service on the specified cluster."
     echo
     echo ${bold}FLAGS${normal}
+    echo "  --profile <profile>         Use a preconfigured profile in the PROFILES configuration variable in heimdall.conf. If the profile isn't found, it's ignored."
+    echo "  ${bold}NOTE:${normal}                       Every configurable variable found in heimdall.conf can be passed as a flag. The format is to use lowercase, kebab-case names with a value. Example:"
     echo "  --awscli-profile <profile>  Switches your AWSCLI profile to a different one in your .aws/config file."
     echo
     echo ${bold}EXAMPLES${normal}

--- a/heimdall.sample.conf
+++ b/heimdall.sample.conf
@@ -4,6 +4,8 @@
 BASTION_HOST_NAME=
 BASTION_DNS_NAME=
 
+BASTION_HOST_PORT=22
+
 # What is your username on the bastion?
 BASTION_USER=ec2-user
 
@@ -16,3 +18,16 @@ AWSCLI_PROFILE=
 
 # This is the default ssh key file. Modify location as needed.
 SSH_KEY_FILE=~/.ssh/id_rsa
+
+# This allows overrides depending on the awscli profile and can be triggered by passing --profile instead of --awscli-profile
+# note: Passing --profile will also set the AWSCLI_PROFILE config variable as that value
+PROFILES='{
+    "profile-1": {
+        "BASTION_HOST_PORT": 123,
+        "BASTION_USER": "some-user"
+    },
+    "profile-2": {
+        "BASTION_HOST_PORT": 234,
+        "BASTION_USER": "some-user"
+    }
+}'


### PR DESCRIPTION
Since we use --awscli-profile for the awscli profile, I decided to add a
--profile option which allows you to preconfigure different profiles so
you're not running overly long and redundant commands.